### PR TITLE
- xPatternPos: fix `restrict_line_index`

### DIFF
--- a/classes/xPatternPos.lua
+++ b/classes/xPatternPos.lua
@@ -38,7 +38,7 @@ end
 
 function xPatternPos.jump_to_line(line_idx)
   TRACE("xPatternPos.jump_to_line(line_idx)",line_idx)
-  line_idx = xSongPos.restrict_line_index(rns.selected_pattern,line_idx)
+  line_idx = xPatternPos.restrict_line_index(line_idx)
   rns.selected_line_index = line_idx
 end
 


### PR DESCRIPTION
I have experienced an issue while using Duplex/[StepSequencer](https://github.com/renoise/xrnx/blob/master/Tools/com.renoise.Duplex.xrnx/Docs/Applications/StepSequencer.md) and it seems like the following minor change has fixed it for me. Whenever `-ln` and `+ln` buttons have been pressed, Duplex used to throw an error and I had to release my Launchpad Mini. I am not into Lua, but `StepSequencer:post_jump_update` calls `xPatternPos.jump_to_line`, which calls `xPatternPos.restrict_line_index`, which seems to handle only one argument. I am not sure why it was called as `xSongPos` method, since it was declared a few lines above (in `xPatternPos`).